### PR TITLE
Add MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt


### PR DESCRIPTION
`requirements.txt` needs to part of the release tarball. Otherwise `setup.py` is not able to populate the [`install_requires`](https://github.com/nazywam/AutoIt-Ripper/blob/master/setup.py#L16).

Could you please publish a new release after merging this or tag the source?

Thanks.