### PR TITLE
Handle the case when there is AU06 script with magic

### DIFF
--- a/autoit_ripper/autoit_unpack.py
+++ b/autoit_ripper/autoit_unpack.py
@@ -154,11 +154,15 @@ def unpack_ea05(binary_data: bytes) -> Optional[List[Tuple[str, bytes]]]:
     au_off = binary_data.index(EA05_MAGIC)
     stream = ByteStream(binary_data[au_off + 20:])
 
-    if stream.get_bytes(4) != b"EA05":
+    magic = stream.get_bytes(4)
+    if magic == b"EA05":
+        parsed_data = parse_all(stream, AutoItVersion.EA05)
+    elif magic == b"EA06":
+        parsed_data = parse_all(stream, AutoItVersion.EA06)
+    else:
         log.error("EA05 magic mismatch")
         return None
 
-    parsed_data = parse_all(stream, AutoItVersion.EA05)
     if not parsed_data:
         log.error("Couldn't decode the autoit script")
         return None


### PR DESCRIPTION
Example: `632ffc57bc8ccc27bac4838575402a8794bd5a168acba012d557c10dbcadaba4`.

Maybe I should refactor `unpack_ea05` name to something more generic, but I didn't want to do significant changes before checking if this makes sense.