### PR TITLE
Don't crash when PE has no resources

### DIFF
--- a/autoit_ripper/autoit_unpack.py
+++ b/autoit_ripper/autoit_unpack.py
@@ -173,7 +173,7 @@ def unpack_ea06(binary_data: bytes) -> Optional[List[Tuple[str, bytes]]]:
         return None
 
     pe.parse_data_directories()
-    if not pe.DIRECTORY_ENTRY_RESOURCE:
+    if not hasattr(pe, "DIRECTORY_ENTRY_RESOURCE") or not pe.DIRECTORY_ENTRY_RESOURCE:
         log.error("The input file has no resources")
         return None
 


### PR DESCRIPTION
Don't crash like this:
```
  File "/usr/local/lib/python3.9/site-packages/autoit_ripper/autoit_unpack.py", line 176, in unpack_ea06
    if not pe.DIRECTORY_ENTRY_RESOURCE:
AttributeError: 'PE' object has no attribute 'DIRECTORY_ENTRY_RESOURCE'
```