### PR TITLE
Don't crash when PE file has no magic

### DIFF
--- a/autoit_ripper/autoit_unpack.py
+++ b/autoit_ripper/autoit_unpack.py
@@ -167,7 +167,10 @@ def unpack_ea05(binary_data: bytes) -> Optional[List[Tuple[str, bytes]]]:
 
 
 def unpack_ea06(binary_data: bytes) -> Optional[List[Tuple[str, bytes]]]:
-    pe = pefile.PE(data=binary_data, fast_load=True)
+    try:
+        pe = pefile.PE(data=binary_data, fast_load=True)
+    except pefile.PEFormatError:
+        pe = None
     if not pe:
         log.error("Failed to parse the input file")
         return None


### PR DESCRIPTION
Don't crash like this:
```
  File "/usr/local/lib/python3.9/site-packages/autoit_ripper/autoit_unpack.py", line 170, in unpack_ea06
    pe = pefile.PE(data=binary_data, fast_load=True)
  File "/usr/local/lib/python3.9/site-packages/pefile.py", line 2895, in __init__
    self.__parse__(name, data, fast_load)
  File "/usr/local/lib/python3.9/site-packages/pefile.py", line 3031, in __parse__
    raise PEFormatError("DOS Header magic not found.")
pefile.PEFormatError: 'DOS Header magic not found.'
```

Closes #24 