### PR TITLE
Add checking to the resource dir

### DIFF
--- a/autoit_ripper/autoit_unpack.py
+++ b/autoit_ripper/autoit_unpack.py
@@ -173,7 +173,7 @@ def unpack_ea06(binary_data: bytes) -> Optional[List[Tuple[str, bytes]]]:
         return None
 
     pe.parse_data_directories()
-    if not pe.DIRECTORY_ENTRY_RESOURCE:
+    if not hasattr(pe, "DIRECTORY_ENTRY_RESOURCE") or not pe.DIRECTORY_ENTRY_RESOURCE:
         log.error("The input file has no resources")
         return None
 


### PR DESCRIPTION
Error example:

```
Failed to process task - 5f2a6651-fc2b-4a14-b84a-57dd73a80113
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/karton/core/karton.py", line 181, in internal_process
    self.process(self.current_task)
  File "/usr/local/lib/python3.9/site-packages/karton/autoit_ripper/autoit_ripper_karton.py", line 50, in process
    resources = extract(data=sample.content, version=AutoItVersion.EA06)
  File "/usr/local/lib/python3.9/site-packages/autoit_ripper/autoit_unpack.py", line 206, in extract
    return unpack_ea06(data)
  File "/usr/local/lib/python3.9/site-packages/autoit_ripper/autoit_unpack.py", line 176, in unpack_ea06
    if not pe.DIRECTORY_ENTRY_RESOURCE:
AttributeError: 'PE' object has no attribute 'DIRECTORY_ENTRY_RESOURCE'
```